### PR TITLE
Use HTTPS URLs for submodules instead of SSH URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "src/Oro"]
 	path = src/Oro
-	url = git@github.com:orocrm/platform.git
+	url = https://github.com/orocrm/platform.git
 [submodule "src/OroPackages/src/Oro/Bundle/EntitySerializedFieldsBundle"]
 	path = src/OroPackages/src/Oro/Bundle/EntitySerializedFieldsBundle
-	url = git@github.com:orocrm/OroEntitySerializedFieldsBundle.git
+	url = https://github.com/orocrm/OroEntitySerializedFieldsBundle.git
 [submodule "src/OroB2B"]
 	path = src/OroB2B
-	url = git@github.com:orocommerce/orocommerce.git
+	url = https://github.com/orocommerce/orocommerce.git


### PR DESCRIPTION
When pushing to a Git server which cannot connect to Github via SSH (or needs to be granted an SSH key to do so), the submodules can't be downloaded.

This PR is replacing the SSH URLs which need an SSH key, with ``https://`` URLs. We could also use plain ``git://`` URLs in that case but HTTPS seems better.